### PR TITLE
Wip adding strength claim

### DIFF
--- a/backend/model/article.js
+++ b/backend/model/article.js
@@ -33,6 +33,10 @@ const ArticleSchema = new mongoose.Schema({
         type:String,
         required: false,
     },
+    claimStrength:{
+        type:String,
+        required: false,
+    },
     claim:{
         type:String,
         required: false,

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,7 @@
 import React from "react";
 // We use Route in order to define the different routes of our application
 import { Route, Routes } from "react-router-dom";
- 
+
 // We import all the components we need in our app
 import Navbar from "./components/navbar";
 import RecordList from "./components/articleList";
@@ -9,21 +9,22 @@ import Edit from "./components/edit";
 import Create from "./components/create";
 import ModeratorList from "./components/moderatorList";
 import AnalystList from "./components/analystList";
- 
-const App = () => 
-{
- return (
-   <div>
-     <Navbar />
-     <Routes>
-       <Route exact path="/" element={<RecordList />} />
-       <Route path="/create" element={<Create />} />
-       <Route path="/moderator" element={<ModeratorList />} />
-       <Route path="/analyst" element={<AnalystList />} />
-       <Route path="/edit" element={<Edit />} />
-     </Routes>
-   </div>
- );
+import { BrowserRouter } from "react-router-dom";
+const App = () => {
+  return (
+    <>
+      <BrowserRouter>
+        <Navbar />
+        <Routes>
+          <Route exact path="/" element={<RecordList />} />
+          <Route path="/create" element={<Create />} />
+          <Route path="/moderator" element={<ModeratorList />} />
+          <Route path="/analyst" element={<AnalystList />} />
+          <Route path="/edit" element={<Edit />} />
+        </Routes>
+      </BrowserRouter>
+    </>
+  );
 };
- 
+
 export default App;

--- a/frontend/src/components/articleList.js
+++ b/frontend/src/components/articleList.js
@@ -9,7 +9,7 @@ import SyncIcon from '@mui/icons-material/Sync';
 export default function ArticleList() {
   const [articles, setArticles] = useState([]);
   const rows = articles.map(
-    ({ _id, title, author, year, volume, number, pages, doi, claim }) => ({
+    ({ _id, title, author, year, volume, number, pages, doi, claim,claimStrength }) => ({
       id: _id,
       title,
       author,
@@ -19,6 +19,7 @@ export default function ArticleList() {
       pages,
       doi,
       claim,
+      claimStrength
     })
   );
 
@@ -56,11 +57,12 @@ export default function ArticleList() {
     { field: "pages", headerName: "Pages", width: 100 },
     { field: "doi", headerName: "Doi", width: 100 },
     { field: "claim", headerName: "Claim Type", width: 100 },
+    {field: "claimStrength",headerName:"Claim Strength",width:150},
   ];
   // This method fetches the records from the database.
   useEffect(() => {
     async function getArticles() {
-      await axios.get("/article").then((res) => {
+      await axios.get("http://localhost:5000/article").then((res) => {
         console.log(res);
         if (!res.statusText === "OK") {
           console.log("checking for articles");

--- a/frontend/src/components/create.js
+++ b/frontend/src/components/create.js
@@ -17,7 +17,8 @@ export default function Create() {
     number: '',
     pages: '',
     doi: '',
-    claim: ''
+    claim: '',
+    claimStrength: ''
   });
 
   const navigate = useNavigate();
@@ -82,7 +83,9 @@ export default function Create() {
       number: "",
       pages: "",
       doi: "",
-      claim: ""
+      claim: "",
+      claimStrength: ''
+
     });
     navigate("/");
   }
@@ -184,6 +187,17 @@ export default function Create() {
             <option value="Component Driven Development">Component Driven Development</option>
             <option value="Integration Driven Development">Integration Driven Development</option>
             <option value="Systems Development">Systems Development</option>
+
+          </select>
+
+        </div>
+        <div className="form-group">
+          <label htmlFor="claimStrength">Claim Strength</label>
+          <select id="claim" name="claim" onChange={(e) => updateForm({ claim: e.target.value })}>
+            <option value="Strongly Agree">Strongly Agree</option>
+            <option value="Agree">Agree</option>
+            <option value="Disagree">Disagree</option>
+            <option value="Strongly disagree">Strongly disagree</option>
 
           </select>
 

--- a/frontend/src/components/create.js
+++ b/frontend/src/components/create.js
@@ -193,7 +193,7 @@ export default function Create() {
         </div>
         <div className="form-group">
           <label htmlFor="claimStrength">Claim Strength</label>
-          <select id="claim" name="claim" onChange={(e) => updateForm({ claim: e.target.value })}>
+          <select id="claimStrength" name="claimStrength" onChange={(e) => updateForm({ claimStrength: e.target.value })}>
             <option value="Strongly Agree">Strongly Agree</option>
             <option value="Agree">Agree</option>
             <option value="Disagree">Disagree</option>

--- a/frontend/src/components/create.test.js
+++ b/frontend/src/components/create.test.js
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import App from "../App"
+import userEvent from "@testing-library/user-event";
+import { BrowserRouter as Router } from "react-router-dom";
+
+describe("Testing Create", () => {
+
+    it("Render Create Article Page", async () => {
+        render(
+            <App />
+        );
+        const user = userEvent;
+        const navigateCreatePage = screen.getByRole("link", { name: /Create New Article/i })
+        await user.click(navigateCreatePage);
+
+        const submisionPage = screen.getByRole("heading", { name: "Submit an Article" })
+
+        expect(submisionPage).toBeInTheDocument();
+    })
+
+    it("User input in text fields", async () => {
+        render(<App />);
+
+        const user = userEvent;
+        const navigateCreatePage = screen.getByRole("link", { name: /Create New Article/i })
+        await user.click(navigateCreatePage);
+
+        const submisionPage = screen.getByRole("textbox", { name: "Title" });
+        await user.type(submisionPage, "Test Title");
+        expect(submisionPage).toHaveValue("Test Title");
+    })
+
+    it("Submit with claim strength", async () => {
+        render(<App />);
+
+        const user = userEvent;
+        const navigateCreatePage = screen.getByRole("link", { name: /Create New Article/i })
+        await user.click(navigateCreatePage);
+
+        const submisionPage = screen.getByRole('combobox',{name: "Claim Strength"});
+        expect(submisionPage).toHaveValue('Strongly Agree');
+
+        expect(screen.getByRole('option', { name: 'Strongly Agree' }).selected).toBe(true)
+    })
+})

--- a/frontend/src/components/edit.js
+++ b/frontend/src/components/edit.js
@@ -35,6 +35,9 @@ function computeMutation(newRow, oldRow) {
   if (newRow.claim !== oldRow.claim) {
     return `Claim from '${oldRow.claim}' to '${newRow.claim}'`;
   }
+  if (newRow.claimStrength !== oldRow.claimStrength) {
+    return `Claim Strength from '${oldRow.claimStrength}' to '${newRow.claimStrength}'`;
+  }
 
   return null;
 }
@@ -42,7 +45,7 @@ function computeMutation(newRow, oldRow) {
 export default function Edit() {
   const [articles, setArticles] = useState([]);
   const rows = articles.map(
-    ({ _id, title, author, year, volume, number, pages, doi, claim }) => ({
+    ({ _id, title, author, year, volume, number, pages, doi, claim, claimStrength }) => ({
       id: _id,
       title,
       author,
@@ -51,7 +54,7 @@ export default function Edit() {
       number,
       pages,
       doi,
-      claim,
+      claim, claimStrength
     })
   );
   const columns = [
@@ -63,6 +66,8 @@ export default function Edit() {
     { field: "pages", headerName: "Pages", width: 100, editable: true },
     { field: "doi", headerName: "Doi", width: 100, editable: true },
     { field: "claim", headerName: "Claim Type", width: 100, editable: true },
+    { field: "claimStrength", headerName: "Claim Strength", width: 100, editable: true },
+
   ];
 
   // This method fetches the articles from the database.
@@ -126,6 +131,7 @@ export default function Edit() {
           pages: newRow.pages,
           doi: newRow.doi,
           claim: newRow.claim,
+          claimStrength: newRow.claimStrength
         },
       });
       // Make the HTTP request to save in the backend
@@ -138,7 +144,7 @@ export default function Edit() {
     }
   };
 
-  const handleEntered = () => {};
+  const handleEntered = () => { };
 
   const renderConfirmDialog = () => {
     if (!promiseArguments) {

--- a/frontend/src/components/edit.js
+++ b/frontend/src/components/edit.js
@@ -66,7 +66,7 @@ export default function Edit() {
     { field: "pages", headerName: "Pages", width: 100, editable: true },
     { field: "doi", headerName: "Doi", width: 100, editable: true },
     { field: "claim", headerName: "Claim Type", width: 100, editable: true },
-    { field: "claimStrength", headerName: "Claim Strength", width: 100, editable: true },
+    { field: "claimStrength", headerName: "Claim Strength", width: 150, editable: true },
 
   ];
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,13 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
-import { BrowserRouter } from "react-router-dom";
 
 ReactDOM.render(
   <React.StrictMode>
-    <BrowserRouter>
       <App />
-    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById("root")
 );


### PR DESCRIPTION
Adding a new field to create.js so that a submitter may add how strong an article's claim is. 

This includes implementing new additions to the main page/edit page and back-end routes in order to accommodate changes to the structure of an article in the database.

Create.test.js is also created which tests the presence of the claim strength combo box on the create.js page as well as the rendering of the first option